### PR TITLE
fix: unwrap /_next/image URLs to original src

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-markdown-mirror",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-markdown-mirror",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "linkedom": "^0.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-markdown-mirror",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Self-hosted Markdown for AI agents — serve Markdown instead of HTML when AI agents request it",
   "type": "module",
   "exports": {

--- a/src/core/converter.ts
+++ b/src/core/converter.ts
@@ -69,6 +69,16 @@ export class HtmlToMarkdown {
       includeSelectors: this.config.includeSelectors,
     });
 
+    // Unwrap /_next/image URLs to original src
+    if (this.config.unwrapNextImages !== false) {
+      this.unwrapNextImageUrls(
+        clone as unknown as {
+          querySelectorAll(s: string): ArrayLike<Element>;
+        },
+        this.config.baseUrl,
+      );
+    }
+
     // Resolve relative URLs
     if (this.config.baseUrl) {
       this.resolveUrls(
@@ -126,6 +136,22 @@ export class HtmlToMarkdown {
     };
   }
 
+  private unwrapNextImageUrls(
+    root: { querySelectorAll(s: string): ArrayLike<Element> },
+    baseUrl?: string,
+  ): void {
+    const imgs = root.querySelectorAll('img[src]');
+    for (let i = 0; i < imgs.length; i++) {
+      const src = imgs[i].getAttribute('src');
+      if (!src) continue;
+
+      const originalUrl = extractNextImageUrl(src, baseUrl);
+      if (originalUrl) {
+        imgs[i].setAttribute('src', originalUrl);
+      }
+    }
+  }
+
   private resolveUrls(
     root: { querySelectorAll(s: string): ArrayLike<Element> },
     baseUrl: string,
@@ -155,6 +181,30 @@ export class HtmlToMarkdown {
         }
       }
     }
+  }
+}
+
+/**
+ * Extract the original image URL from a /_next/image wrapper URL.
+ * Returns the unwrapped URL, or undefined if not a Next.js image URL.
+ */
+function extractNextImageUrl(src: string, baseUrl?: string): string | undefined {
+  // Match both relative (/_next/image/...) and absolute (https://site.com/_next/image/...)
+  if (!src.includes('/_next/image')) return undefined;
+
+  try {
+    // Parse using a dummy base if the src is relative
+    const parsed = new URL(src, baseUrl ?? 'http://localhost');
+    const originalUrl = parsed.searchParams.get('url');
+    if (!originalUrl) return undefined;
+
+    // If the extracted URL is relative, resolve it with baseUrl if available
+    if (!isAbsoluteUrl(originalUrl) && baseUrl) {
+      return new URL(originalUrl, baseUrl).href;
+    }
+    return originalUrl;
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -31,6 +31,9 @@ export interface MarkdownMirrorConfig {
   /** Base URL for resolving relative URLs in the HTML. */
   baseUrl?: string;
 
+  /** Whether to unwrap /_next/image URLs to their original src. Default: true */
+  unwrapNextImages?: boolean;
+
   /** Maximum content size in bytes before rejecting. Default: 1MB */
   maxContentSize?: number;
 

--- a/test/core/converter.test.ts
+++ b/test/core/converter.test.ts
@@ -150,6 +150,39 @@ describe('HtmlToMarkdown', () => {
     expect(result.tokenCount).toBeGreaterThanOrEqual(0);
   });
 
+  it('unwraps /_next/image URLs to original src', () => {
+    const html = readFixture('simple-page.html');
+    const converter = new HtmlToMarkdown({ baseUrl: 'https://example.com' });
+    const result = converter.convert(html);
+
+    // Should contain the original image URL, not the /_next/image wrapper
+    expect(result.markdown).toContain('https://cdn.example.com/photo.jpg');
+    expect(result.markdown).not.toContain('/_next/image');
+  });
+
+  it('keeps /_next/image URLs when unwrapNextImages is false', () => {
+    const html = readFixture('simple-page.html');
+    const converter = new HtmlToMarkdown({
+      baseUrl: 'https://example.com',
+      unwrapNextImages: false,
+    });
+    const result = converter.convert(html);
+
+    // Should keep the /_next/image URL (resolved to absolute)
+    expect(result.markdown).toContain('https://example.com/_next/image/');
+  });
+
+  it('unwraps /_next/image with relative inner URL and resolves with baseUrl', () => {
+    const html = `<html><body><main>
+      <img src="/_next/image/?url=%2Fuploads%2Fphoto.jpg&amp;w=1920&amp;q=75" alt="test">
+    </main></body></html>`;
+    const converter = new HtmlToMarkdown({ baseUrl: 'https://example.com' });
+    const result = converter.convert(html);
+
+    expect(result.markdown).toContain('https://example.com/uploads/photo.jpg');
+    expect(result.markdown).not.toContain('/_next/image');
+  });
+
   it('accepts custom token counter', () => {
     const html = readFixture('simple-page.html');
     const converter = new HtmlToMarkdown({

--- a/test/fixtures/simple-page.html
+++ b/test/fixtures/simple-page.html
@@ -37,6 +37,7 @@
 console.log(x);</code></pre>
     <img src="/images/photo.jpg" alt="A photo" width="800" height="600">
     <img src="/icons/small.png" alt="icon" width="16" height="16">
+    <img src="/_next/image/?url=https%3A%2F%2Fcdn.example.com%2Fphoto.jpg&amp;w=3840&amp;q=75" alt="Next.js optimized image" width="800" height="600">
   </main>
   <footer>
     <p>Copyright 2025</p>


### PR DESCRIPTION
## Summary
- Unwraps `/_next/image/?url=...` wrapper URLs to extract the original image source during HTML→Markdown conversion
- Adds `unwrapNextImages` config option (default: `true`) to control this behavior
- Relative URLs inside the `/_next/image` wrapper are also resolved when `baseUrl` is set

Closes #2

## Test plan
- [x] Added test: `/_next/image` URLs are unwrapped to original URLs
- [x] Added test: unwrapping can be disabled with `unwrapNextImages: false`
- [x] Added test: relative inner URLs are resolved with `baseUrl`
- [x] All 93 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)